### PR TITLE
Made identifying directory root Windows-compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(options) {
     return through.obj(function (file, enc, callback) {
 
         if (first) {
-            options.dirRoot = options.dirRoot || file.base.replace(/\/$/, "");
+            options.dirRoot = options.dirRoot || file.base.replace(/[\/\\]$/, "");
             gutil.log('gulp-cloudfront:', 'Root directory [', options.dirRoot, ']');
             first = !first;
         }


### PR DESCRIPTION
Windows uses backslashes as a path separator, so the previous regex wasn't matching against the trailing slash - now it does. Tested on Windows 8.1 and Arch Linux :+1: 
