### PR TITLE
Supply sessionToken used for temporary credentials

### DIFF
--- a/tool.js
+++ b/tool.js
@@ -10,7 +10,8 @@ module.exports = function(options) {
 
     var cloudfront = new AWS.CloudFront({
         accessKeyId: options.key,
-        secretAccessKey: options.secret
+        secretAccessKey: options.secret,
+        sessionToken: options.sessionToken
     });
 
     var updateDefaultRootObject = function (defaultRootObject) {

--- a/tool.js
+++ b/tool.js
@@ -45,6 +45,15 @@ module.exports = function(options) {
                 // Update the distribution with the new default root object (trim the precedeing slash)
                 data.DistributionConfig.DefaultRootObject = defaultRootObject.substr(1);
 
+                // Update the 404 error to point at the defaultRootObject 
+                // This is really only required for SPA apps - but since this is our branch!
+                data.DistributionConfig.CustomErrorResponses.Items.forEach(function(item) {
+                    if (item.ErrorCode === 404) {
+                        item.ResponsePagePath = defaultRootObject;
+                    }
+                });
+
+
                 cloudfront.updateDistribution({
                     IfMatch: data.ETag,
                     Id: options.distributionId,


### PR DESCRIPTION
The session token is a required parameter for AWS connections using temporary credentials - such as those offered by instance roles / credentials and when using STS:AssumeRole (i.e. IAM)
